### PR TITLE
Cleaning up comments and some other minor compatibility changes

### DIFF
--- a/Contentful.Wyam/Contentful.cs
+++ b/Contentful.Wyam/Contentful.cs
@@ -23,12 +23,10 @@ namespace Contentful.Wyam
     /// For each Entry in Contentful one output document per requested locale will be created. For each output document every field of the Entry will be available
     /// as metadata. In addition a number of other metadata properties will be set for each document.
     /// </remarks>
-    /// <metadata name="ContentfulId" type="string">The id of the Entry. Note that this is not guaranteed to unique as there will be one document created per requested locale of the Entry.
-    /// A unique combination would be ContentfulId and ContentfulLocale.
-    /// </metadata>
-    /// <metadata name="ContentfulLocale" type="string">The locale of the Entry.</metadata>
-    /// <metadata name="ContentfulIncludedAssets" type="IEnumerable{Asset}">The included assets of the Entry. Refer to the Contentful .NET SDK documentation for more details.</metadata>
-    /// <metadata name="ContentfulIncludedEntries" type="IEnumerable{Entry<dynamic>}">The included referenced entries of the Entry. Refer to the Contentful .NET SDK documentation for more details.</metadata>
+    /// <metadata cref="ContentfulKeys.EntryId" usage="Output" />
+    /// <metadata cref="ContentfulKeys.EntryLocale" usage="Output" />
+    /// <metadata cref="ContentfulKeys.IncludedAssets" usage="Output" />
+    /// <metadata cref="ContentfulKeys.IncludedEntries" usage="Output" />
     /// <category>Content</category>
     public class Contentful : IModule
     {
@@ -151,6 +149,7 @@ namespace Contentful.Wyam
             return this;
         }
 
+        /// <inheritdoc />
         public IEnumerable<IDocument> Execute(IReadOnlyList<IDocument> inputs, IExecutionContext context)
         {
             Space space = null;
@@ -241,7 +240,7 @@ namespace Contentful.Wyam
                     metaData.Add(new KeyValuePair<string, object>(ContentfulKeys.EntryLocale, localeCode));
                     metaData.Add(new KeyValuePair<string, object>(ContentfulKeys.IncludedAssets, includedAssets));
                     metaData.Add(new KeyValuePair<string, object>(ContentfulKeys.IncludedEntries, includedEntries));
-                    var doc = context.GetDocument(content, metaData);
+                    var doc = context.GetDocument(context.GetContentStream(content), metaData);
 
                     yield return doc;
                 }

--- a/Contentful.Wyam/ContentfulKeys.cs
+++ b/Contentful.Wyam/ContentfulKeys.cs
@@ -11,9 +11,31 @@ namespace Contentful.Wyam
     /// </summary>
     public static class ContentfulKeys
     {
-        public static string EntryId => "ContentfulId";
-        public static string EntryLocale => "ContentfulLocale";
-        public static string IncludedAssets => "ContentfulIncludedAssets";
-        public static string IncludedEntries => "ContentfulIncludedEntries";
+        /// <summary>
+        /// The id of the Entry. Note that this is not guaranteed to unique as there will be one document created per requested locale of the Entry.
+        /// A unique combination would be <see cref="EntryId"/> and <see cref="EntryLocale"/>. The string version of this key is "ContentfulId".
+        /// </summary>
+        /// <type><see cref="string"/></type>
+        public const string EntryId = "ContentfulId";
+
+        /// <summary>
+        /// The locale of the Entry. The string version of this key is "ContentfulLocale".
+        /// </summary>
+        /// <type><see cref="string"/></type>
+        public const string EntryLocale = "ContentfulLocale";
+
+        /// <summary>
+        /// The included assets of the Entry. Refer to the Contentful .NET SDK documentation for more details.
+        /// The string version of this key is "ContentfulIncludedAssets".
+        /// </summary>
+        /// <type><c>IEnumerable&lt;Asset&gt;</c></type>
+        public const string IncludedAssets = "ContentfulIncludedAssets";
+
+        /// <summary>
+        /// The included referenced entries of the Entry. Refer to the Contentful .NET SDK documentation for more details.
+        /// The string version of this key is "ContentfulIncludedEntries".
+        /// </summary>
+        /// <type><c>IEnumerable&lt;Entry&lt;dynamic&gt;&gt;</c></type>
+        public const string IncludedEntries = "ContentfulIncludedEntries";
     }
 }


### PR DESCRIPTION
Whelp, it took [essentially rewriting the CodeAnalysis module](https://github.com/Wyamio/Wyam/issues/493), but I've finally got good support for third-party addins on the site :smile:

This PR cleans up the doc comments to match a new convention that was recently introduced to make metadata comments easier to manage. It also fixes a deprecated use of `IExecutionContext.GetDocument()`. Looking good with the changes:

![2017-04-12_16h16_20](https://cloud.githubusercontent.com/assets/1020407/24977671/d2319c16-1f9b-11e7-912d-f5b10a6f265f.png)
